### PR TITLE
feat: Reveal cards and reset game buttons

### DIFF
--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -1,6 +1,12 @@
 <mat-card class="player-card" [ngClass]="{ 'active-player': isActive }">
   <mat-card-title>{{ playerName }}</mat-card-title>
   <mat-card-content>
-    <div *ngIf="selectedCard" class="card">{{ selectedCard }}</div>
+    <div
+      *ngIf="selectedCard"
+      class="card"
+      [ngClass]="{ 'current-player-card': isCurrentPlayer }"
+    >
+      {{ selectedCard }}
+    </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/player/player.component.scss
+++ b/src/app/player/player.component.scss
@@ -1,5 +1,3 @@
-@import 'src/styles/variables';
-
 .player-card {
   border: 1px solid #ccc;
   border-radius: 8px;
@@ -19,5 +17,5 @@
   margin-top: 16px;
   font-size: 24px;
   font-weight: bold;
-  color: mat-color($primary);
+  color: #007bff;
 }

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -9,4 +9,5 @@ export class PlayerComponent {
   @Input() playerName: string = '';
   @Input() selectedCard: string = '';
   @Input() isActive: boolean = false;
+  @Input() isCurrentPlayer: boolean = false;
 }

--- a/src/app/poker/poker.component.html
+++ b/src/app/poker/poker.component.html
@@ -1,6 +1,6 @@
 <div class="poker">
   <div *ngIf="errorMessage" class="error">{{ errorMessage }}</div>
-  <div *ngIf="!readyToPlay" class="player-name-input">
+  <div class="player-name-input" *ngIf="!readyToPlay">
     <mat-form-field>
       <mat-label>Enter your name</mat-label>
       <input
@@ -17,8 +17,13 @@
     <app-player
       *ngFor="let player of players | keyvalue"
       [playerName]="player.value"
-      [selectedCard]="selectedCards.get(player.value) || ''"
+      [selectedCard]="
+        cardSelections.get(player.value) ||
+        selectedCards.get(player.value) ||
+        ''
+      "
       [isActive]="isActivePlayer(player.value)"
+      [isCurrentPlayer]="isCurrentPlayer(player.value)"
     ></app-player>
   </div>
   <div class="cards" *ngIf="readyToPlay">
@@ -26,8 +31,25 @@
       mat-raised-button
       *ngFor="let card of cards"
       (click)="selectCard(card)"
+      [ngClass]="{ 'selected-card': isCardSelected(card) }"
     >
       {{ card }}
+    </button>
+    <button
+      mat-raised-button
+      color="accent"
+      (click)="revealCards()"
+      [disabled]="gameState.revealed"
+    >
+      Reveal Cards
+    </button>
+    <button
+      mat-raised-button
+      color="warn"
+      (click)="resetGame()"
+      *ngIf="gameState.revealed"
+    >
+      Reset Game
     </button>
   </div>
 </div>

--- a/src/app/poker/poker.component.scss
+++ b/src/app/poker/poker.component.scss
@@ -21,3 +21,8 @@
     padding: 10px 20px;
   }
 }
+
+.selected-card {
+  border: 2px solid #28a745;
+  box-shadow: 0 2px 8px rgba(40, 167, 69, 0.5);
+}

--- a/src/app/poker/poker.component.ts
+++ b/src/app/poker/poker.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Socket } from 'ngx-socket-io';
 
+interface GameState {
+  revealed: boolean;
+}
+
 @Component({
   selector: 'app-poker',
   templateUrl: './poker.component.html',
@@ -10,9 +14,14 @@ export class PokerComponent implements OnInit, OnDestroy {
   players: Map<string, string> = new Map(); // Map for player IDs and names
   cards = ['1', '2', '3', '5', '8', '13', '21', '?'];
   selectedCards: Map<string, string> = new Map(); // Map for player names and selected cards
+  cardSelections: Map<string, string> = new Map(); // Map for player names and selected card symbols ('-' or actual card)
   playerName: string | null = null;
   errorMessage: string | null = null;
   readyToPlay: boolean = false;
+  gameState: GameState = {
+    revealed: false,
+  };
+  currentPlayerCard: string | null = null;
 
   constructor(private socket: Socket) {}
 
@@ -25,11 +34,16 @@ export class PokerComponent implements OnInit, OnDestroy {
       'updateSelectedCards',
       (selectedCards: { [key: string]: string }) => {
         this.selectedCards = new Map(Object.entries(selectedCards));
+        this.cardSelections = new Map(Object.entries(selectedCards));
       },
     );
 
-    this.socket.on('cardSelected', (data: any) => {
-      this.selectedCards.set(data.playerName, data.selectedCard);
+    this.socket.on('updateGameState', (state: GameState) => {
+      this.gameState = state;
+    });
+
+    this.socket.on('cardSelected', (playerName: string) => {
+      this.cardSelections.set(playerName, '-');
     });
   }
 
@@ -55,17 +69,19 @@ export class PokerComponent implements OnInit, OnDestroy {
   }
 
   selectCard(card: string) {
-    if (!this.readyToPlay) {
+    if (!this.readyToPlay || this.gameState.revealed || !this.playerName) {
       return;
     }
-    const playerName = this.players.get(this.socket.ioSocket.id);
-    if (playerName) {
-      this.selectedCards.set(playerName, card);
-      this.socket.emit('cardSelected', {
-        playerName: playerName,
-        selectedCard: card,
-      });
-    }
+    this.socket.emit('cardSelected', {
+      playerName: this.playerName,
+      selectedCard: card,
+    });
+    this.cardSelections.set(this.playerName, '-');
+    this.currentPlayerCard = card;
+  }
+
+  revealCards() {
+    this.socket.emit('revealCards');
   }
 
   isActivePlayer(playerName: string): boolean {
@@ -73,5 +89,19 @@ export class PokerComponent implements OnInit, OnDestroy {
       return false;
     }
     return this.playerName === playerName;
+  }
+
+  resetGame() {
+    this.socket.emit('resetGame');
+    this.cardSelections.clear();
+    this.currentPlayerCard = null;
+  }
+
+  isCurrentPlayer(playerName: string): boolean {
+    return this.playerName === playerName;
+  }
+
+  isCardSelected(card: string): boolean {
+    return this.currentPlayerCard === card;
   }
 }


### PR DESCRIPTION
- New reveal cards feature: now players won't see card selections until cards get revealed
![image](https://github.com/gabriel-maciel/planning-poker-web/assets/30875244/cd4eb51a-f2d7-4ea4-a4a0-7cdc7dcf3537)
- New reset game feature: when cards are revealed, players need reset the game to start a new votation
![image](https://github.com/gabriel-maciel/planning-poker-web/assets/30875244/59d720d6-edef-4f08-8be3-3ae86225ce2c)
